### PR TITLE
First UI code

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "immutable": "^3.8.1",
     "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2"
   }
 }

--- a/src/components/Voting.jsx
+++ b/src/components/Voting.jsx
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+
+class Voting extends Component {
+  getPair() {
+    return this.props.pair || [];
+  }
+  
+  render() {
+    return (
+      <div className='voting'>
+        {this.getPair().map(entry =>
+          <button key={entry}>
+            <h1>{entry}</h1>
+          </button>
+        )}                
+      </div>
+    );
+  }
+}
+
+export default Voting;

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-console.log('I am alive!!!');

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Voting from './components/Voting';
+
+const pair = ['Following', 'Memento'];
+
+ReactDOM.render(
+  <Voting pair={pair} />,
+  document.getElementById('app')
+);

--- a/test/components/Voting_spec.jsx
+++ b/test/components/Voting_spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { renderIntoDocument, scryRenderedDOMComponentsWithTag } from 'react-addons-test-utils';
+import { expect } from 'chai';
+
+import Voting from '../../src/components/Voting';
+
+describe('Voting', () => {
+  it('renders a pair of buttons', () => {
+    const component = renderIntoDocument(
+      <Voting pair={['Following', 'Memento']} />
+    );
+    const buttons = scryRenderedDOMComponentsWithTag(component, 'button');    
+    expect(buttons.length).to.equal(2);
+    expect(buttons[0].textContent).to.equal('Following');
+    expect(buttons[1].textContent).to.equal('Memento');
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,17 +4,17 @@ module.exports = {
   entry: [
     'webpack-dev-server/client?http://localhost:8080',
     'webpack/hot/only-dev-server',
-    './src/index.js'
+    './src/index.jsx'
   ],
   module: {
     loaders: [{
       test: /\.jsx?$/,
       exclude: /node_modules/,
-      loader: 'react-hot!babel'
+      loader: 'react-hot-loader!babel-loader'
     }]
   },
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['.js', '.jsx']
   },
   output: {
     path: __dirname + '/dist',


### PR DESCRIPTION
## Description

Webpack was complaining about the extensions (apparently, the empty string {i. e. ' '} extension was not required) being empty and that the loaders had to be suffixed with _-loader_. Fixed both.

### Tech change(s)
- **Basic** component which renders two buttons for the vote. 
- `index` to mount component.
- Test for component.